### PR TITLE
Rename to rssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <h1>reactriot2019-bashinbastions 🥊</h1>
+  <h1>rssh 🥊</h1>
 </div>
 
 <p align="center">
@@ -144,7 +144,7 @@ Similar to the previous command, except this will close the tunnel.
 ### Clone this repo
 
 ```bash
-$ git clone https://github.com/Hackbit/reactriot2019-bashinbastions.git
+$ git clone https://github.com/thgaskell/rssh-cli.git
 $ cd reactriot2019-bashinbastions
 ```
 

--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Hackbit/reactriot2019-bashinbastions.git"
+    "url": "https://github.com/thgaskell/rssh-cli.git"
   },
   "bugs": {
-    "url": "https://github.com/Hackbit/reactriot2019-bashinbastions/issues"
+    "url": "https://github.com/thgaskell/rssh-cli/issues"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Fixes #11

Rename instances of 'reactriot2019-bashinbastions' to 'rssh' in `README.md` and `package.json`.

* **README.md**
  - Update the title to 'rssh'.
  - Update the clone URL to 'https://github.com/thgaskell/rssh-cli.git'.

* **package.json**
  - Update the repository URL to 'https://github.com/thgaskell/rssh-cli.git'.
  - Update the bugs URL to 'https://github.com/thgaskell/rssh-cli/issues'.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/thgaskell/rssh-cli/issues/11?shareId=eb3ddeea-149a-4cb2-9223-b1628c5b6563).